### PR TITLE
fix: disable load when building multiple platforms

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ runs:
         cache-to: type=gha,mode=max
         context: ${{ inputs.context }}
         file: ${{ inputs.working-directory }}/${{ inputs.dockerfile }}
-        load: ${{ inputs.push != 'true' }}
+        load: ${{ inputs.push != 'true' && !contains(inputs.platforms, ',') }}
         push: ${{ inputs.push == 'true' }}
         platforms: ${{ inputs.platforms }}
         tags: ${{ steps.metadata.outputs.tags }}


### PR DESCRIPTION
Apparently load is not supported for manifest lists: 
https://github.com/kronostechnologies/webapp-boilerplate/runs/7727604626