### PR TITLE
Turn provenance off to reduce image by build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -164,6 +164,7 @@ runs:
         labels: ${{ steps.metadata.outputs.labels }}
         load: ${{ inputs.push != 'true' && !contains(inputs.platforms, ',') }}
         no-cache: ${{ inputs.no-cache == 'true' }}
+        provenance: false
         pull: ${{ inputs.pull == 'true' }}
         push: ${{ inputs.push == 'true' }}
         platforms: ${{ inputs.platforms }}


### PR DESCRIPTION
Basé sur cette discussion, https://github.com/aws/containers-roadmap/issues/1596- avec la documentation https://docs.docker.com/build/attestations/slsa-provenance/.

On peut désactiver les `provenance` images, ça va permettre de diminuer de 5 images par build à 3 images. J'estime sans risque parce que l'on ne s'en sert pas.